### PR TITLE
Allow usage of PHP 8.0+ OpenSSLCertificate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
+    - php: 8.1
+    - php: 8.2
 
 install:
   - composer self-update

--- a/lib/Certificate.php
+++ b/lib/Certificate.php
@@ -42,16 +42,16 @@ class Certificate
             if (!$cert = @\openssl_x509_read($pem)) {
                 throw new InvalidCertificateException("Invalid PEM encoded certificate!");
             }
-        } else {
-            if (\is_resource($pem)) {
-                if (\get_resource_type($pem) !== "OpenSSL X.509") {
-                    throw new InvalidCertificateException("Invalid resource of type other than 'OpenSSL X.509'!");
-                }
-
-                $cert = $pem;
-            } else {
-                throw new \InvalidArgumentException("Invalid variable type, expected string|resource, got " . \gettype($pem));
+        } elseif ($pem instanceof \OpenSSLCertificate) {
+            $cert = $pem;
+        } elseif (\is_resource($pem)) {
+            if (\get_resource_type($pem) !== "OpenSSL X.509") {
+                throw new InvalidCertificateException("Invalid resource of type other than 'OpenSSL X.509'!");
             }
+
+            $cert = $pem;
+        } else {
+            throw new \InvalidArgumentException("Invalid variable type, expected string|resource, got " . \gettype($pem));
         }
 
         if (\openssl_x509_export($pem, $this->pem) === false) {


### PR DESCRIPTION
OpenSSLCertificate replaces the X509 resource in PHP 8.0:
https://www.php.net/manual/en/class.opensslcertificate.php 